### PR TITLE
Add dotenv to devDependencies

### DIFF
--- a/custom-login/package.json
+++ b/custom-login/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^12.11.1",
     "@types/text-encoding": "0.0.36",
     "codelyzer": "^6.0.0",
+    "dotenv": "^8.2.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
     "protractor": "~7.0.0",

--- a/okta-hosted-login/package.json
+++ b/okta-hosted-login/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^12.11.1",
     "@types/text-encoding": "0.0.36",
     "codelyzer": "^6.0.0",
+    "dotenv": "^8.2.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
     "protractor": "~7.0.0",


### PR DESCRIPTION
Add `dotenv` to `devDependencies`
(`dotenv` is listed in `devDependencies` for root but not in actual samples dirs - `custom_login` and `okta-hosted-login`)

Internal ref: [OKTA-450240](https://oktainc.atlassian.net/browse/OKTA-450240)